### PR TITLE
Summarize

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,15 +2,56 @@ package main
 
 import (
 	"flag"
+	"fmt"
 	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/koron/nvcheck/internal/ahocorasick"
 )
 
 var (
 	dict = flag.String("d", "dict.yml", "variability dictionary")
+	fpat = flag.String("m", `\.(txt)$`, "pattern of the file")
+	fre  *regexp.Regexp
 )
+
+func findFile(s Summary, m *ahocorasick.Matcher, name string) error {
+	fi, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+	if fi.IsDir() {
+		return filepath.Walk(name, func(path string, fi os.FileInfo, err error) error {
+			if fi != nil && fi.Mode().IsRegular() {
+				if !fre.MatchString(path) {
+					return nil
+				}
+				checkFile(s, m, path)
+			}
+			return nil
+		})
+	}
+	if !fre.MatchString(name) {
+		return nil
+	}
+	return checkFile(s, m, name)
+}
 
 func main() {
 	flag.Parse()
+	if flag.NArg() == 0 {
+		flag.Usage()
+		os.Exit(2)
+	}
+
+	re, err := regexp.Compile(*fpat)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fre = re
+
 	d, err := loadDict(*dict)
 	if err != nil {
 		log.Fatal(err)
@@ -19,7 +60,14 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	summary := make(Summary)
 	for _, n := range flag.Args() {
-		findFile(m, n)
+		if err := findFile(summary, m, n); err != nil {
+			log.Printf("failed to operate file: %v", n)
+		}
+	}
+	if len(summary) > 0 {
+		fmt.Println(summary)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -69,5 +69,6 @@ func main() {
 	}
 	if len(summary) > 0 {
 		fmt.Println(summary)
+		os.Exit(1)
 	}
 }

--- a/summary.go
+++ b/summary.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type Fix struct {
+	ln    int
+	found *Found
+}
+
+type Result map[string][]Fix
+
+type Summary map[string]Result
+
+func (s Summary) Add(name string, ln int, m *Found) {
+	_, ok := s[m.Fix]
+	if !ok {
+		s[m.Fix] = make(Result)
+	}
+	s[m.Fix][name] = append(s[m.Fix][name], Fix{ln, m})
+}
+
+func (s Summary) String() string {
+	var buf bytes.Buffer
+	for k, v := range s {
+		fmt.Fprintln(&buf, k)
+		for kk, vv := range v {
+			fmt.Fprintln(&buf, "  "+kk)
+			for _, f := range vv {
+				fmt.Fprintf(&buf, "    %s at %d\n", f.found.Text, f.ln)
+			}
+		}
+	}
+	return buf.String()
+}


### PR DESCRIPTION
CI から使いやすくしてみました(のつもりです)

引数にディレクトリを受けられる様にしたので

```
$ nvcheck .
ユーザー
  example\test.txt
    ユーザ at 2
    ユーザ at 6
サーバー
  example\test.txt
    サーバ at 4
```

こう出ます。出力は行番号にしています。`-m` でマッチさせるファイル名のパターンを変えられるので

```
$ nvcheck -m "\.(txt|yml)$" .
ユーザー
  example\test.txt
    ユーザ at 2
    ユーザ at 6
  dict.yml
    ユーザ at 1
サーバー
  dict.yml
    サーバ at 3
  example\test.txt
    サーバ at 4
```

こんな感じに統括的にチェックできるかと思います。
