### PR TITLE
Fixed error when replacing long word to short word.

### DIFF
--- a/find_test.go
+++ b/find_test.go
@@ -109,6 +109,12 @@ const dict0 = `
 
 foo bar:
   - foobar
+
+FBB:
+  - FooBarBaz
+
+QuxQuux:
+  - QQ
 `
 
 func parseDict(t *testing.T, s string) Dict {

--- a/replace.go
+++ b/replace.go
@@ -86,6 +86,9 @@ func replaceFounds(c *ctx, w io.Writer) error {
 				}
 			}
 			if f {
+				if len(fix) == 0 {
+					continue
+				}
 				r, fix = fix[0], fix[1:]
 			}
 		}

--- a/replace_test.go
+++ b/replace_test.go
@@ -40,4 +40,10 @@ func TestReplace(t *testing.T) {
 	testReplace(t, d, "word includes white 1", "foo bar", "foo bar")
 	testReplace(t, d, "word includes white 2", "foo  bar", "foo  bar")
 	testReplace(t, d, "word includes white 3", "foo\nbar", "foo\nbar")
+
+	testReplace(t, d, "long to short", "FooBarBaz", "FBB")
+	testReplace(t, d, "long to short with pref post", "AbcFooBarBazDef", "AbcFBBDef")
+
+	testReplace(t, d, "short to long", "QQ", "QuxQuux")
+	testReplace(t, d, "short to long with pref post", "AbcQQDef", "AbcQuxQuuxDef")
 }


### PR DESCRIPTION
長い文字列を短い文字列に置換しようとするとエラーになっていたのを修正しました。
テストを追加しました。